### PR TITLE
[#33] stay on traffic light until car passes light (instead of stop line)

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -220,7 +220,7 @@ class TLDetector(object):
         self.camera_image = msg
         image_num = self.img_count
         rospy.logdebug("tl_detector: image_cb processing image %d",image_num)
-        light_wp, state = self.process_traffic_lights(image_num)
+        stop_wp, state = self.process_traffic_lights(image_num)
 
         '''
         Publish upcoming red lights at camera frequency.
@@ -234,10 +234,10 @@ class TLDetector(object):
         elif self.state_count >= STATE_COUNT_THRESHOLD:
             self.last_state = self.state
             #report light if red or yellow, so we don't freak out or blow the stop line when it suddenly turns red
-            light_wp = light_wp if state == TrafficLight.RED or state == TrafficLight.YELLOW else -1
-            self.last_wp = light_wp
-            self.upcoming_red_light_pub.publish(Int32(light_wp))
-            rospy.logdebug("tl_detector: from image %d (vs. current image %d), published waypoint of next red light's stop line: %d",image_num,self.img_count,light_wp)
+            stop_wp = stop_wp if state == TrafficLight.RED or state == TrafficLight.YELLOW else -1
+            self.last_wp = stop_wp
+            self.upcoming_red_light_pub.publish(Int32(stop_wp))
+            rospy.logdebug("tl_detector: from image %d (vs. current image %d), published waypoint of next red light's stop line: %d",image_num,self.img_count,stop_wp)
         else:
             self.upcoming_red_light_pub.publish(Int32(self.last_wp))
             rospy.logdebug("tl_detector: from image %d (vs. current image %d), published waypoint of prevously reported red light's stop line: %d",image_num,self.img_count,self.last_wp)
@@ -339,7 +339,7 @@ class TLDetector(object):
         """
         rospy.logdebug("tl_detector: entered process_traffic_lights")
         light = None
-        light_wp = 1
+        stop_wp = 1
 
         # List of positions that correspond to the line to stop in front of for a given intersection.  already saved this to tl_list
         #stop_line_positions = self.config['stop_line_positions']
@@ -363,11 +363,11 @@ class TLDetector(object):
                 if (wps_to_tl < wps_to_closest_tl):
                     wps_to_closest_tl = wps_to_tl
                     light = i
-                    light_wp = tl_hash['stop_wp']
+                    stop_wp = tl_hash['stop_wp']
 
         if light is not None or PARKING_LOT_TEST:
             state = self.get_light_state(light,image_num)
-            return light_wp, state
+            return stop_wp, state
 
         rospy.logwarn("tl_detector: process_traffic_lights did not find any light that was next.  this shouldn't happen")
         self.waypoints = None

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -32,7 +32,7 @@ LOOKAHEAD_WPS   = 200   # Number of waypoints we will publish. For Test Lot, ple
 CIRCULAR_WPS    = False # If True, assumes that the path to follow is a loop
 REFRESH_RATE_HZ = 50     # Number of times we update the final waypoints per second should be 50Hz for submission
 DEBUG_MODE      = False # Switch for whether debug messages are printed.
-TL_DETECTOR_ON  = False  # If False, switches to direct traffic light subscription
+TL_DETECTOR_ON  = False # If False, switches to direct traffic light subscription
 DECELLERATION   = 3     # Decelleration in m/s^2
 
 

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -32,7 +32,7 @@ LOOKAHEAD_WPS   = 200   # Number of waypoints we will publish. For Test Lot, ple
 CIRCULAR_WPS    = False # If True, assumes that the path to follow is a loop
 REFRESH_RATE_HZ = 50     # Number of times we update the final waypoints per second should be 50Hz for submission
 DEBUG_MODE      = False # Switch for whether debug messages are printed.
-TL_DETECTOR_ON  = False # If False, switches to direct traffic light subscription
+TL_DETECTOR_ON  = False  # If False, switches to direct traffic light subscription
 DECELLERATION   = 3     # Decelleration in m/s^2
 
 
@@ -73,7 +73,7 @@ class WaypointUpdater(object):
         if DEBUG_MODE:
             rospy.logwarn('waypoint_updater: DEBUG mode enabled - Disable for submission')
 
-        if TL_DETECTOR_ON:
+        if not TL_DETECTOR_ON:
             rospy.logwarn('waypoint_updater: Traffic Light Detector disabled - Enable for submission')
 
         if REFRESH_RATE_HZ < 50:
@@ -162,7 +162,7 @@ class WaypointUpdater(object):
                 for wp in wp_indices:
                     tl_wp = self.static_waypoints[self.next_red_tl_wp]
                     check_wp = self.static_waypoints[wp]
-                    if self.distance_to_previous(check_wp.pose.pose) > self.distance_to_previous(tl_wp.pose.pose) - 1:
+                    if self.distance_to_previous(check_wp.pose.pose) > self.distance_to_previous(tl_wp.pose.pose) - 3.0: #center of car should stop 3 meters before stop line
                         self.set_waypoint_id_velocity(wp, 0.0)
                     else:
                         dist_wp_to_stop = euclidean_distance(check_wp, tl_wp)


### PR DESCRIPTION
tl_detector reports the coordinates of the traffic light's stop line, but now doesn't move to the next light until the car passes the acutal light.  This is so if the car misses the stop line by a bit, it doesn't run the red light.  

change waypoint_updater to stop with center of car 3m behind stop line (was previously 1m)

Change waypoint_updater warning message to report when tl_detector is disabled, instead of enabled.  