### PR TITLE
[#38] tl_detector: base tl waypoint on stopline, not light coord

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -357,7 +357,11 @@ class TLDetector(object):
         i = 0
         if self.tl_list:
             for tl_hash in self.tl_list: #check all lights to find closest. 
-                wps_to_tl = tl_hash['light_wp'] - car_position
+
+                #report next traffic light as soon as car crosses stopo line, as half-images don't detect correctly
+                #wps_to_tl = tl_hash['light_wp'] - car_position
+                wps_to_tl = tl_hash['stop_wp'] - car_position
+
                 if (wps_to_tl < 0):   # we've wrapped around waypoint list to beginning
                     wps_to_tl += self.num_wp
                 if (wps_to_tl < wps_to_closest_tl):


### PR DESCRIPTION
Reverts tl_detector to reporting the next traffic light whose stopline is in front of the car, instead of whose traffic light is in front of the car.  

This should fix issue #38 , where the car stops in the middle of an intersection and does not proceed, because a light cut off at the top of the frame is detected as yellow.  The car will still detect this as yellow, but will report the waypoint of the next traffic light instead of the current, so the car should proceed through this intersection.  

I had changed tl_detector to base the waypoint off the traffic light when I saw the car not quite stop in time, and then run through a red light.  However, I think that's fixed by waypoint_updater having the car's center-point stop 3m behind the stopline, instead of 1m.  